### PR TITLE
Change obsolete library libcurl3 and libcurl3-dev by their udpated ones

### DIFF
--- a/bin/webserver/Dockerfile
+++ b/bin/webserver/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update --fix-missing && \
     apt-utils nano wget dialog \
     fish vim \
     # Install important libraries
-    build-essential git curl libcurl3 libcurl3-dev zip openssl
+    build-essential git curl libcurl4 libcurl4-gnutls-dev zip openssl
 
 # Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \


### PR DESCRIPTION
I had to choose the library for the dev among:
- libcurl4-openssl-dev 7.47.0-1ubuntu2.2
- libcurl4-nss-dev 7.47.0-1ubuntu2.2
- libcurl4-gnutls-dev 7.47.0-1ubuntu2.2
and I chose libcurl4-gnutls-dev as the SSL support is provided by GnuTLS.